### PR TITLE
fix: Handles long messages in /yogalog

### DIFF
--- a/src/commands/yogalog.js
+++ b/src/commands/yogalog.js
@@ -3,34 +3,36 @@ import { getXataClient } from "./../xata.js";
 
 export default {
   data: new SlashCommandBuilder()
-    .setName('yogalog')
-    .setDescription('Lists all your yoga sessions')
-    .addStringOption(option =>
-      option.setName('period')
+    .setName("yogalog")
+    .setDescription("Lists all your yoga sessions")
+    .addStringOption((option) =>
+      option
+        .setName("period")
         .setDescription("Which period to list")
         .setRequired(false)
         .addChoices(
           {
             name: "Week",
-            value: "week"
+            value: "week",
           },
           {
             name: "Month",
-            value: "month"
+            value: "month",
           },
           {
             name: "Year",
-            value: "year"
+            value: "year",
           }
         )
     ),
 
   async execute(interaction, xata = getXataClient()) {
     const discordUserId = interaction.user.id;
-    const period = interaction.options.getString('period');
+    const period = interaction.options.getString("period");
 
-    let results = await xata.db.session
-      .filter({discordUserId: discordUserId})
+    let results = await xata.db.session.filter({
+      discordUserId: discordUserId,
+    });
 
     if (period) {
       const start = new Date();
@@ -45,16 +47,43 @@ export default {
           start.setFullYear(start.getFullYear() - 1);
           break;
       }
-      results = results.filter({sessionTimestamp: {$gt: start}});
+      results = results.filter({ sessionTimestamp: { $gt: start } });
     }
 
-    results = await results.getAll();
-    let output = `Days of yoga: ${results.length}\n`
+    results = await results.sort("sessionTimestamp", "asc").getAll();
+    let header = `Days of yoga: ${results.length}\n`;
     if (period) {
-      output += `Period: ${period}\n`
+      header += `Period: ${period}\n`;
     }
-    output += results.map(row => `- ${row.sessionDateString}: ${row.note}`).join("\n")
 
-    await interaction.reply({ content: output, ephemeral: true});
+    const rows = results.map((row) => {
+      const result = `- ${row.sessionDateString}: ${row.note}`;
+      if (result.length > 2000) {
+        return result.slice(0, 2000);
+      }
+
+      return result;
+    });
+
+    const totalLength = rows.reduce((acc, row) => acc + row.length, 0);
+    if (totalLength + header.length > 2000) {
+      const reply = `${header}Too many rows to display, will send as DM.`;
+      await interaction.reply({ content: reply, ephemeral: true });
+      let message = header;
+      for (const row of rows) {
+        if (message.length + row.length > 2000) {
+          await interaction.user.send(message);
+          message = "";
+        }
+        message += row + "\n";
+      }
+
+      await interaction.user.send(message);
+    } else {
+      await interaction.reply({
+        content: `${header}${rows.join("\n")}`,
+        ephemeral: true,
+      });
+    }
   },
 };

--- a/src/services/yoga-logger.js
+++ b/src/services/yoga-logger.js
@@ -12,7 +12,7 @@ export function truncate(str, maxLength) {
 
 export function allowedMessage(message) {
   const isNotBot = !message.author.bot;
-  const inYogaChannel = message.channel.name.toLowerCase() === "yoga";
+  const inYogaChannel = message.channel?.name?.toLowerCase() === "yoga";
   const startsWithCheckMark = message.content.trim().startsWith("✅");
 
   const isAllowed = isNotBot && inYogaChannel && startsWithCheckMark;
@@ -27,8 +27,6 @@ export async function createOrUpdateYogaSession(
   message,
   xata = getXataClient()
 ) {
-
-
   if (!allowedMessage(message)) return;
 
   const messageContent = message.content.trim();
@@ -156,7 +154,9 @@ export default (discordClient) => {
     const command = interaction.client.commands.get(interaction.commandName);
 
     if (!command) {
-      console.error(`No command matching ${interaction.commandName} was found.`);
+      console.error(
+        `No command matching ${interaction.commandName} was found.`
+      );
       return;
     }
 


### PR DESCRIPTION
The discord bot can only send 2000 characters at a time
and cannot send multiple answers to the initial command.
So instead it will send the results as a DM.
# Month that still works
<img width="1130" alt="Screenshot 2023-02-25 at 10 40 52" src="https://user-images.githubusercontent.com/6763624/221350292-4871bb41-01fd-4883-ba0f-055aba1a16f2.png">

# All history that was too long
<img width="1130" alt="Screenshot 2023-02-25 at 10 40 59" src="https://user-images.githubusercontent.com/6763624/221350294-0098c4af-1d38-462a-b98d-bd89feeac769.png">

